### PR TITLE
Spawner tweak

### DIFF
--- a/plugin/src/main/java/misat11/bw/game/Game.java
+++ b/plugin/src/main/java/misat11/bw/game/Game.java
@@ -1655,7 +1655,7 @@ public class Game implements misat11.bw.api.Game {
 						if ((elapsedTime % cycle) == 0) {
 
 							BedwarsResourceSpawnEvent resourceSpawnEvent = new BedwarsResourceSpawnEvent(this, spawner,
-									type.getStack(upgrades ? spawner.currentLevel : 1));
+									type.getStack(upgrades ? max(floor((elapsedTime / cycle) * spawner.currentLevel) - floor(((elapsedTime / cycle) - 1) * spawner.currentLevel), 0) : 1));
 							Main.getInstance().getServer().getPluginManager().callEvent(resourceSpawnEvent);
 
 							if (resourceSpawnEvent.isCancelled()) {

--- a/plugin/src/main/java/misat11/bw/game/Game.java
+++ b/plugin/src/main/java/misat11/bw/game/Game.java
@@ -748,7 +748,8 @@ public class Game implements misat11.bw.api.Game {
 			for (Map<String, Object> spawner : spawners) {
 				ItemSpawner sa = new ItemSpawner(readLocationFromString(game.world, (String) spawner.get("location")),
 						Main.getSpawnerType(((String) spawner.get("type")).toLowerCase()),
-						(String) spawner.get("customName"), (int) spawner.getOrDefault("startLevel", 1));
+						(String) spawner.get("customName"), (int) spawner.getOrDefault("startLevel", 1),
+						(bool) spawner.getOrDefault("hologramVisible", true));
 				game.spawners.add(sa);
 			}
 		}
@@ -942,6 +943,7 @@ public class Game implements misat11.bw.api.Game {
 			spawnerMap.put("type", spawner.type.getConfigKey());
 			spawnerMap.put("customName", spawner.customName);
 			spawnerMap.put("startLevel", spawner.startLevel);
+			spawnerMap.put("hologramVisible", spawner.hologramVisible);
 			nS.add(spawnerMap);
 		}
 		configMap.set("spawners", nS);
@@ -1441,6 +1443,9 @@ public class Game implements misat11.bw.api.Game {
 					if (getOriginalOrInheritedSpawnerHolograms()) {
 						boolean countdownEnabled = getOriginalOrInheritedSpawnerHologramsCountdown();
 						for (ItemSpawner spawner : spawners) {
+							if (!spawner.hologramVisible) {
+								continue;
+							}
 							Location loc = spawner.loc.clone().add(0,
 									Main.getConfigurator().config.getDouble("spawner-holo-height", 0.25), 0);
 							if (countdownEnabled) {

--- a/plugin/src/main/java/misat11/bw/game/GameCreator.java
+++ b/plugin/src/main/java/misat11/bw/game/GameCreator.java
@@ -626,7 +626,7 @@ public class GameCreator {
 		loc.setPitch(0);
 		ItemSpawnerType spawnerType = Main.getSpawnerType(type);
 		if (spawnerType != null) {
-			game.getSpawners().add(new ItemSpawner(loc, spawnerType, customName, startLevel));
+			game.getSpawners().add(new ItemSpawner(loc, spawnerType, customName, startLevel, true));
 			return i18n("admin_command_spawner_added").replace("%resource%", spawnerType.getItemName())
 					.replace("%x%", Integer.toString(loc.getBlockX())).replace("%y%", Integer.toString(loc.getBlockY()))
 					.replace("%z%", Integer.toString(loc.getBlockZ()));

--- a/plugin/src/main/java/misat11/bw/game/ItemSpawner.java
+++ b/plugin/src/main/java/misat11/bw/game/ItemSpawner.java
@@ -8,12 +8,14 @@ public class ItemSpawner implements misat11.bw.api.ItemSpawner {
 	public String customName;
 	public int startLevel = 1;
 	public int currentLevel = startLevel;
+	public bool hologramVisible;
 	
-	public ItemSpawner(Location loc, ItemSpawnerType type, String customName, int startLevel) {
+	public ItemSpawner(Location loc, ItemSpawnerType type, String customName, int startLevel, bool hologramVisible) {
 		this.loc = loc;
 		this.type = type;
 		this.customName = customName;
 		this.startLevel = startLevel;
+		this.hologramVisible = hologramVisible;
 	}
 
 	@Override
@@ -44,5 +46,10 @@ public class ItemSpawner implements misat11.bw.api.ItemSpawner {
 	@Override
 	public int getCurrentLevel() {
 		return currentLevel;
+	}
+
+	@Override
+	public int getHologramVisible() {
+		return hologramVisible;
 	}
 }


### PR DESCRIPTION
## Description
- You can now hide holograms for particular spawners. `hologramVisible` property added for that (default = true).
- Added negative numbers and fractions support in spawner level.

**Tested minecraft versions:**
Needs testing! I don't even know if that's compiling properly.
### Screenshots (if appropriate):
None
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
