### PR TITLE
Add new special item: Golem

### DIFF
--- a/api/src/main/java/misat11/bw/api/special/Golem.java
+++ b/api/src/main/java/misat11/bw/api/special/Golem.java
@@ -1,0 +1,15 @@
+package misat11.bw.api.special;
+
+import org.bukkit.entity.LivingEntity;
+
+public interface Golem extends SpecialItem {
+
+	public LivingEntity getEntity();
+
+	public boolean isUsed();
+
+	public double getSpeed();
+
+	public double getFollowRange();
+
+}

--- a/plugin/src/main/java/misat11/bw/special/Golem.java
+++ b/plugin/src/main/java/misat11/bw/special/Golem.java
@@ -1,0 +1,72 @@
+package misat11.bw.special;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import misat11.bw.Main;
+import misat11.bw.api.Game;
+import misat11.bw.api.Team;
+import misat11.bw.game.TeamColor;
+import misat11.lib.nms.NMSUtils;
+
+public class Golem extends SpecialItem implements misat11.bw.api.special.Golem {
+
+	private LivingEntity entity;
+	private Location loc;
+	private double speed, followRange;
+	private boolean used = false;
+
+	public Golem(Game game, Player player, Team team, Location loc, double speed, double followRange) {
+		super(game, player, team);
+		this.loc = loc;
+		this.speed = speed;
+		this.followRange = followRange;
+		game.registerSpecialItem(this);
+	}
+
+	public boolean use() {
+		if (!used) {
+			TeamColor color = TeamColor.fromApiColor(team.getColor());
+			IronGolem golem = (IronGolem) loc.getWorld().spawnEntity(loc, EntityType.IRON_GOLEM);
+
+			FileConfiguration config = Main.getConfigurator().config;
+			String name = config.getString("specials.golem.name-format", "%teamcolor%%team% Golem");
+			assert name != null;
+			name = name.replace("%teamcolor%", color.chatColor.toString()).replace("%team%", team.getName());
+			golem.setCustomName(name);
+			golem.setCustomNameVisible(config.getBoolean("specials.golem.show-name", true));
+			entity = golem;
+
+			NMSUtils.makeMobTargetNearestAttackable(golem, "EntityPlayer", speed, followRange);
+
+			Main.registerGameEntity(golem, (misat11.bw.game.Game) game);
+			used = true;
+		}
+		return used;
+	}
+
+	@Override
+	public LivingEntity getEntity() {
+		return entity;
+	}
+
+	@Override
+	public boolean isUsed() {
+		return used;
+	}
+
+	@Override
+	public double getSpeed() {
+		return speed;
+	}
+
+	@Override
+	public double getFollowRange() {
+		return followRange;
+	}
+
+}

--- a/plugin/src/main/java/misat11/bw/special/SpecialRegister.java
+++ b/plugin/src/main/java/misat11/bw/special/SpecialRegister.java
@@ -3,6 +3,7 @@ package misat11.bw.special;
 import org.bukkit.plugin.Plugin;
 
 import misat11.bw.special.listener.ArrowBlockerListener;
+import misat11.bw.special.listener.GolemListener;
 import misat11.bw.special.listener.LuckyBlockAddonListener;
 import misat11.bw.special.listener.MagnetShoesListener;
 import misat11.bw.special.listener.ProtectionWallListener;
@@ -13,8 +14,10 @@ import misat11.bw.special.listener.TrapListener;
 import misat11.bw.special.listener.WarpPowderListener;
 
 public class SpecialRegister {
+
 	public static void onEnable(Plugin plugin) {
 		plugin.getServer().getPluginManager().registerEvents(new ArrowBlockerListener(), plugin); // TODO
+		plugin.getServer().getPluginManager().registerEvents(new GolemListener(), plugin);
 		plugin.getServer().getPluginManager().registerEvents(new LuckyBlockAddonListener(), plugin);
 		plugin.getServer().getPluginManager().registerEvents(new MagnetShoesListener(), plugin); // TODO
 		plugin.getServer().getPluginManager().registerEvents(new ProtectionWallListener(), plugin); // TODO
@@ -24,4 +27,5 @@ public class SpecialRegister {
 		plugin.getServer().getPluginManager().registerEvents(new TrapListener(), plugin);
 		plugin.getServer().getPluginManager().registerEvents(new WarpPowderListener(), plugin);
 	}
+
 }

--- a/plugin/src/main/java/misat11/bw/special/listener/GolemListener.java
+++ b/plugin/src/main/java/misat11/bw/special/listener/GolemListener.java
@@ -1,0 +1,179 @@
+package misat11.bw.special.listener;
+
+import java.util.List;
+
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.entity.EntityTargetEvent.TargetReason;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import misat11.bw.Main;
+import misat11.bw.api.APIUtils;
+import misat11.bw.api.Game;
+import misat11.bw.api.GameStatus;
+import misat11.bw.api.events.BedwarsApplyPropertyToBoughtItem;
+import misat11.bw.api.special.SpecialItem;
+import misat11.bw.game.GamePlayer;
+import misat11.bw.special.Golem;
+
+public class GolemListener implements Listener {
+
+	public static final String GOLEM_PREFIX = "Module:Golem:";
+
+	@EventHandler
+	public void onGolemRegistered(BedwarsApplyPropertyToBoughtItem event) {
+		if (event.getPropertyName().equalsIgnoreCase("golem")) {
+			ItemStack stack = event.getStack();
+
+			String specialString = GOLEM_PREFIX + event.getDoubleProperty("speed") + ":"
+					+ event.getDoubleProperty("follow");
+
+			APIUtils.hashIntoInvisibleString(stack, specialString);
+		}
+
+	}
+
+	@EventHandler
+	public void onGolemUsed(PlayerInteractEvent event) {
+		if (event.isCancelled() && event.getAction() != Action.RIGHT_CLICK_AIR) {
+			return;
+		}
+
+		if (!Main.isPlayerInGame(event.getPlayer())) {
+			return;
+		}
+
+		Player eventPlayer = event.getPlayer();
+		GamePlayer gamePlayer = Main.getPlayerGameProfile(eventPlayer);
+		Game game = gamePlayer.getGame();
+		if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+			if (game.getStatus() == GameStatus.RUNNING && !gamePlayer.isSpectator) {
+				if (event.getItem() != null) {
+					ItemStack stack = event.getItem();
+					String unhidden = APIUtils.unhashFromInvisibleStringStartsWith(stack, GOLEM_PREFIX);
+					if (unhidden != null) {
+						event.setCancelled(true);
+						String[] splitted = unhidden.split(":");
+						double speed = Double.parseDouble(splitted[2]);
+						double follow = Double.parseDouble(splitted[3]);
+						Location startLocation;
+						if (event.getClickedBlock() == null) {
+							startLocation = eventPlayer.getLocation();
+						} else {
+							startLocation = event.getClickedBlock().getRelative(BlockFace.UP)
+									.getLocation().add(0.5, 0.5, 0.5);
+						}
+						Golem golem = new Golem(game, eventPlayer, game.getTeamOfPlayer(eventPlayer),
+								startLocation, speed, follow);
+						if (golem.use()) {
+							ItemStack replace = null;
+							if (event.getItem().getAmount() > 1) {
+								replace = event.getItem().clone();
+								replace.setAmount(event.getItem().getAmount() - 1);
+							}
+							try {
+								if (event.getHand() == EquipmentSlot.HAND) {
+									eventPlayer.getInventory().setItemInMainHand(replace);
+								} else {
+									eventPlayer.getInventory().setItemInOffHand(replace);
+								}
+							} catch (Throwable t) {
+								eventPlayer.setItemInHand(replace);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onGolemDamage(EntityDamageByEntityEvent event) {
+		if (event.isCancelled()) {
+			return;
+		}
+
+		if (event.getCause().equals(DamageCause.CUSTOM) || event.getCause().equals(DamageCause.VOID)) {
+			return;
+		}
+
+		if (!(event.getEntity() instanceof IronGolem)) {
+			return;
+		}
+
+		if (event.getDamager() instanceof Player) {
+			Player player = (Player) event.getDamager();
+			if (Main.isPlayerInGame(player)) {
+				GamePlayer gamePlayer = Main.getPlayerGameProfile(player);
+				Game game = gamePlayer.getGame();
+				if (!game.getOriginalOrInheritedFriendlyfire()) {
+					for (SpecialItem item : game.getActivedSpecialItems(Golem.class)) {
+						if (item instanceof Golem) {
+							if (((Golem) item).getEntity().equals(event.getEntity())) {
+								if (item.getTeam() == game.getTeamOfPlayer(player)) {
+									event.setCancelled(true);
+								}
+								return;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onGolemTarget(EntityTargetEvent event) {
+		if (event.isCancelled()) {
+			return;
+		}
+
+		if (!(event.getEntity() instanceof IronGolem)) {
+			return;
+		}
+
+		if (event.getReason().equals(TargetReason.CUSTOM)) {
+			return;
+		}
+
+		// When a *golem* targets an entity
+		IronGolem ironGolem = (IronGolem) event.getEntity();
+		for (String name : Main.getGameNames()) {
+			Game game = Main.getGame(name);
+			if (game.getStatus() == GameStatus.RUNNING && ironGolem.getWorld().equals(game.getGameWorld())) {
+				List<SpecialItem> golems = game.getActivedSpecialItems(Golem.class);
+				for (SpecialItem item : golems) {
+					if (item instanceof Golem) {
+						Golem golem = (Golem) item;
+						if (golem.getEntity().equals(ironGolem)) {
+							// Target enemy players only
+							if (event.getTarget() instanceof Player) {
+								Player player = (Player) event.getTarget();
+								if (Main.isPlayerInGame(player)) {
+									if (golem.getTeam() != game.getTeamOfPlayer(player)) {
+										return;
+									}
+								}
+							}
+							// Don't target anything except an enemy player
+							event.setCancelled(true);
+							return;
+						}
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -110,6 +110,9 @@ specials:
     explosion-time: 8
   arrow-blocker:
     protection-time: 10
+  golem:
+    name-format: "%teamcolor%%team% Golem"
+    show-name: true
 
 # Automatic TNT ignite (default: false)
 tnt:

--- a/plugin/src/main/resources/shop.yml
+++ b/plugin/src/main/resources/shop.yml
@@ -614,6 +614,23 @@ data:
             - "Block arrows that are coming"
             - "for you with black magic."
             - "I mean, with this item."
+    - price: 24
+      price-type: iron
+      properties:
+      - name: "Golem"
+        speed: 0.25
+        follow: 16.0
+      stack:
+        ==: org.bukkit.inventory.ItemStack
+        type: GHAST_SPAWN_EGG
+        v: 1519
+        meta:
+          ==: ItemMeta
+          meta-type: UNSPECIFIC
+          display-name: "Golem"
+          lore:
+          - "An iron golem that will protect"
+          - "your team from the enemies."
 
 -   stack:
       ==: org.bukkit.inventory.ItemStack
@@ -665,4 +682,3 @@ data:
           enchants:
             LOOT_BONUS_BLOCKS: 3
             
-        

--- a/plugin/src/main/resources/shop_legacy.yml
+++ b/plugin/src/main/resources/shop_legacy.yml
@@ -533,6 +533,23 @@ data:
               - "Protect yourself from falling into"
               - "void with a Rescue Platform."
               - "This is your last hope!"
+    - price: 24
+      price-type: iron
+      properties:
+      - name: "Golem"
+        speed: 0.25
+        follow: 16.0
+      stack:
+        ==: org.bukkit.inventory.ItemStack
+        type: MONSTER_EGG
+        damage: 56 # Ghast
+        meta:
+          ==: ItemMeta
+          meta-type: UNSPECIFIC
+          display-name: "Golem"
+          lore:
+          - "An iron golem that will protect"
+          - "your team from the enemies."
 
 -   stack:
       ==: org.bukkit.inventory.ItemStack
@@ -583,7 +600,6 @@ data:
               
   
               
-          
           
           
           


### PR DESCRIPTION
## Description
Adds a special item that spawns an iron golem, which will protect the team from the enemies.
- Team mates can't attack to the golems if friendly fire is not allowed, but they won't target their team mates at all.
- The golems will only target enemy players.
- The target system uses the Minecraft pathfinder goals.
- There are shop properties to change the speed and follow range of the golems.
- There is a config option to specify the name of the golems, "%teamcolor%%team% Golem" by default.
- shop.yml, shop_legacy.yml and config.yml are ready.

Requires a NMSUtils version that this is included: https://github.com/Misat11/NMSUtils

**Tested Minecraft versions:** 1.14.4 (should work on 1.8.8 too)

### Screenshot
<img src="https://user-images.githubusercontent.com/19474570/62424598-79da0300-b6d9-11e9-854e-9ac5f97cc703.png" width="300"/>

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
